### PR TITLE
Fix Flutter lint warnings

### DIFF
--- a/lib/app/modules/home/widgets/user_drawer.dart
+++ b/lib/app/modules/home/widgets/user_drawer.dart
@@ -11,7 +11,7 @@ class UserDrawer extends StatelessWidget {
   UserService get _userService => Get.find();
   AccountService get _accountService => Get.find();
 
-  const UserDrawer({Key? key}) : super(key: key);
+  const UserDrawer({super.key});
 
   Widget _buildUserItem(
     BuildContext context, {

--- a/lib/app/modules/media_detail/page.dart
+++ b/lib/app/modules/media_detail/page.dart
@@ -36,9 +36,7 @@ import 'widgets/add_to_playlist/widget.dart';
 import 'widgets/media_desc.dart';
 
 class MediaDetailPage extends StatefulWidget {
-  const MediaDetailPage({
-    Key? key,
-  }) : super(key: key);
+  const MediaDetailPage({super.key});
 
   static final RouteObserver<PageRoute> routeObserver =
       RouteObserver<PageRoute>();
@@ -223,7 +221,7 @@ class _MediaDetailPageState extends State<MediaDetailPage>
         plPlayerController!.removeStatusLister(playerListener);
         plPlayerController!.dispose();
       }
-      _controller.floating?.dispose();
+      _controller.floating?.cancelOnLeavePiP();
       videoPlayerServiceHandler.onVideoDetailDispose();
       _lifecycleListener.dispose();
     }

--- a/lib/app/modules/media_detail/widgets/create_video_download_task/widget.dart
+++ b/lib/app/modules/media_detail/widgets/create_video_download_task/widget.dart
@@ -13,10 +13,10 @@ class CreateVideoDownloadDialog
   final OfflineMediaModel previewData;
 
   const CreateVideoDownloadDialog({
-    Key? key,
+    super.key,
     required this.resolutions,
     required this.previewData,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/modules/media_detail/widgets/gallery/iwr_gallery.dart
+++ b/lib/app/modules/media_detail/widgets/gallery/iwr_gallery.dart
@@ -11,12 +11,12 @@ class IwrGallery extends StatefulWidget {
   final void Function(int index)? onPageChanged;
 
   const IwrGallery({
-    Key? key,
+    super.key,
     required this.imageUrls,
     this.isfullScreen = false,
     this.lastPage,
     this.onPageChanged,
-  }) : super(key: key);
+  });
 
   @override
   State<IwrGallery> createState() => _IwrGalleryState();
@@ -72,7 +72,7 @@ class _IwrGalleryState extends State<IwrGallery> {
   Widget _buildDotPageFooter() {
     return Container(
       decoration: BoxDecoration(
-        color: Colors.black.withOpacity(0.3),
+        color: Colors.black.withAlpha((0.3 * 255).round()),
         borderRadius: BorderRadius.circular(16),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
@@ -96,7 +96,7 @@ class _IwrGalleryState extends State<IwrGallery> {
                 shape: BoxShape.circle,
                 color: _currentIndex == index
                     ? Colors.white
-                    : Colors.white.withOpacity(0.4),
+                    : Colors.white.withAlpha((0.4 * 255).round()),
               ),
             ),
           );
@@ -108,7 +108,7 @@ class _IwrGalleryState extends State<IwrGallery> {
   Widget _buildTextPageFooter() {
     return Container(
       decoration: BoxDecoration(
-        color: Colors.black.withOpacity(0.5),
+        color: Colors.black.withAlpha((0.5 * 255).round()),
         borderRadius: BorderRadius.circular(16),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
@@ -129,7 +129,7 @@ class _IwrGalleryState extends State<IwrGallery> {
         extendBodyBehindAppBar: true,
         backgroundColor: Colors.black,
         appBar: AppBar(
-          backgroundColor: Colors.black.withOpacity(0.5),
+          backgroundColor: Colors.black.withAlpha((0.5 * 255).round()),
           elevation: 0,
           iconTheme: const IconThemeData(color: Colors.white),
           title: widget.imageUrls.length > 1
@@ -183,7 +183,8 @@ class _IwrGalleryState extends State<IwrGallery> {
                 top: 4,
                 child: IconButton(
                   style: IconButton.styleFrom(
-                    backgroundColor: Colors.black.withOpacity(0.3),
+                    backgroundColor:
+                        Colors.black.withAlpha((0.3 * 255).round()),
                   ),
                   onPressed: () {
                     Navigator.of(context).pop();

--- a/lib/app/modules/media_detail/widgets/header_control.dart
+++ b/lib/app/modules/media_detail/widgets/header_control.dart
@@ -48,7 +48,7 @@ class _HeaderControlState extends State<HeaderControl> {
 
   @override
   Widget build(BuildContext context) {
-    final _ = widget.controller!;
+    final controller = widget.controller!;
     const TextStyle textStyle = TextStyle(
       color: Colors.white,
       fontSize: 12,
@@ -121,7 +121,8 @@ class _HeaderControlState extends State<HeaderControl> {
                   final Rational aspectRatio =
                       widget.videoDetailCtr?.aspectRatio ??
                           const Rational(16, 9);
-                  await widget.floating!.enable(aspectRatio: aspectRatio);
+                  await widget.floating!
+                      .enable(ImmediatePiP(aspectRatio: aspectRatio));
                 } else {}
               },
             ),
@@ -134,7 +135,7 @@ class _HeaderControlState extends State<HeaderControl> {
                 child: TextButton(
                   onPressed: () => showSetSpeedSheet(),
                   child: Text(
-                    '${_.playbackSpeed}X',
+                    '${controller.playbackSpeed}X',
                     style: textStyle,
                   ),
                 ),
@@ -183,7 +184,7 @@ class _HeaderControlState extends State<HeaderControl> {
           height: Get.height * 0.6,
           clipBehavior: Clip.hardEdge,
           decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.background,
+            color: Theme.of(context).colorScheme.surface,
             borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
           ),
           child: Column(
@@ -198,7 +199,7 @@ class _HeaderControlState extends State<HeaderControl> {
                       color: Theme.of(context)
                           .colorScheme
                           .onSecondaryContainer
-                          .withOpacity(0.5),
+                          .withAlpha((0.5 * 255).round()),
                       borderRadius: const BorderRadius.all(
                         Radius.circular(4),
                       ),
@@ -272,7 +273,7 @@ class _HeaderControlState extends State<HeaderControl> {
           padding: EdgeInsets.only(bottom: Get.mediaQuery.padding.bottom),
           clipBehavior: Clip.hardEdge,
           decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.background,
+            color: Theme.of(context).colorScheme.surface,
             borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
           ),
           child: Column(
@@ -328,7 +329,7 @@ class _HeaderControlState extends State<HeaderControl> {
           padding: EdgeInsets.only(bottom: Get.mediaQuery.padding.bottom),
           clipBehavior: Clip.hardEdge,
           decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.background,
+            color: Theme.of(context).colorScheme.surface,
             borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
           ),
           child: Column(
@@ -380,7 +381,7 @@ class _HeaderControlState extends State<HeaderControl> {
           padding: EdgeInsets.only(bottom: Get.mediaQuery.padding.bottom),
           clipBehavior: Clip.hardEdge,
           decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.background,
+            color: Theme.of(context).colorScheme.surface,
             borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
           ),
           child: Column(

--- a/lib/app/modules/profile/guestbook/page.dart
+++ b/lib/app/modules/profile/guestbook/page.dart
@@ -12,7 +12,7 @@ import '../../../data/models/user.dart';
 class GuestbookPage extends StatefulWidget {
   final UserModel user;
 
-  const GuestbookPage({Key? key, required this.user}) : super(key: key);
+  const GuestbookPage({super.key, required this.user});
 
   @override
   State<GuestbookPage> createState() => _GuestbookPageState();

--- a/lib/app/modules/profile/uploaded_media/page.dart
+++ b/lib/app/modules/profile/uploaded_media/page.dart
@@ -7,7 +7,7 @@ import '../../../data/models/account/settings/media_sort_setting.dart';
 import 'controller.dart';
 
 class UploadedMediaPage extends StatefulWidget {
-  const UploadedMediaPage({Key? key}) : super(key: key);
+  const UploadedMediaPage({super.key});
 
   @override
   State<StatefulWidget> createState() => _UploadedMediaPageState();

--- a/lib/app/modules/settings/widgets/proxy_dialog.dart
+++ b/lib/app/modules/settings/widgets/proxy_dialog.dart
@@ -7,7 +7,7 @@ import 'package:iwrqk/i18n/strings.g.dart';
 import '../../../data/providers/storage_provider.dart';
 
 class ProxyDialog extends StatelessWidget {
-  const ProxyDialog({super.key});
+  ProxyDialog({super.key});
 
   final FocusNode blankNode = FocusNode();
   final FocusNode focusNode = FocusNode();

--- a/lib/app/modules/tabs/media_grid_tab/page.dart
+++ b/lib/app/modules/tabs/media_grid_tab/page.dart
@@ -27,7 +27,7 @@ class MediaGridTabPage extends StatefulWidget {
     this.sourceType,
     this.customSourceTypeList,
     this.tabAlignment = TabAlignment.start,
-  }) : super(key: key);
+  });
 
   @override
   State<StatefulWidget> createState() => _MediaGridTabPageState();


### PR DESCRIPTION
## Summary
- fix PiP API usage
- clean up constructors with super.key
- replace deprecated `withOpacity` calls with `withAlpha`
- switch to `colorScheme.surface`
- adjust Floating disposal

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_687dbdbec698832c9447361bae6a63b0