### PR TITLE
Fix deprecations and info warnings

### DIFF
--- a/lib/app/components/app_bar_switcher.dart
+++ b/lib/app/components/app_bar_switcher.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 
 class AppBarSwitcher extends StatelessWidget implements PreferredSizeWidget {
   const AppBarSwitcher({
+    super.key,
     required this.primary,
     required this.secondary,
     required this.visible,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final PreferredSizeWidget primary;
   final PreferredSizeWidget secondary;

--- a/lib/app/components/comments_list/widget.dart
+++ b/lib/app/components/comments_list/widget.dart
@@ -21,7 +21,7 @@ class CommentsList extends StatefulWidget {
   final Widget? parentComment;
 
   const CommentsList({
-    Key? key,
+    super.key,
     required this.tag,
     required this.sourceType,
     required this.sourceId,
@@ -33,7 +33,7 @@ class CommentsList extends StatefulWidget {
     this.showBottomPagination = false,
     this.scrollController,
     this.parentComment,
-  }) : super(key: key);
+  });
 
   @override
   State<CommentsList> createState() => _CommentsListState();

--- a/lib/app/components/dialogs/edit_playlis_dialog/widget.dart
+++ b/lib/app/components/dialogs/edit_playlis_dialog/widget.dart
@@ -10,11 +10,11 @@ class EditPlaylistDialog extends GetWidget<EditPlaylistDialogController> {
   final bool isEdit;
 
   const EditPlaylistDialog({
-    Key? key,
+    super.key,
     this.onChanged,
     this.editId,
     this.isEdit = false,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/components/dialogs/loading_dialog/widget.dart
+++ b/lib/app/components/dialogs/loading_dialog/widget.dart
@@ -12,13 +12,13 @@ class LoadingDialog extends GetWidget<LoadingDialogController> {
   final String? errorMessage;
 
   const LoadingDialog({
-    Key? key,
+    super.key,
     required this.task,
     this.successMessage,
     this.errorMessage,
     this.onSuccess,
     this.onFail,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/app/components/double_appbar.dart
+++ b/lib/app/components/double_appbar.dart
@@ -2,11 +2,11 @@ import 'package:flutter/material.dart';
 
 class AppBarWidget extends StatelessWidget implements PreferredSizeWidget {
   const AppBarWidget({
+    super.key,
     required this.child,
     required this.controller,
     required this.visible,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final PreferredSizeWidget child;
   final AnimationController controller;

--- a/lib/app/components/media_preview/media_flat_preview.dart
+++ b/lib/app/components/media_preview/media_flat_preview.dart
@@ -17,12 +17,12 @@ class MediaFlatPreview extends StatelessWidget {
   final void Function()? onLongPress;
 
   const MediaFlatPreview({
-    Key? key,
+    super.key,
     required this.media,
     this.coverOverlay,
     this.onTap,
     this.onLongPress,
-  }) : super(key: key);
+  });
 
   Widget _buildBadges(BuildContext context) {
     Duration? duration;

--- a/lib/app/components/media_preview/media_preview.dart
+++ b/lib/app/components/media_preview/media_preview.dart
@@ -14,9 +14,9 @@ class MediaPreview extends StatelessWidget {
   final MediaModel media;
 
   const MediaPreview({
-    Key? key,
+    super.key,
     required this.media,
-  }) : super(key: key);
+  });
 
   Widget _buildBadges(BuildContext context) {
     Duration? duration;

--- a/lib/app/components/network_image.dart
+++ b/lib/app/components/network_image.dart
@@ -16,14 +16,14 @@ class NetworkImg extends StatefulWidget {
   final bool isAdult;
 
   const NetworkImg({
-    Key? key,
+    super.key,
     required this.imageUrl,
     this.width,
     this.height,
     this.fit,
     this.aspectRatio,
     this.isAdult = false,
-  }) : super(key: key);
+  });
 
   @override
   State<NetworkImg> createState() => _NetworkImgState();

--- a/lib/app/components/plugin/pl_player/view.dart
+++ b/lib/app/components/plugin/pl_player/view.dart
@@ -167,7 +167,7 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
 
   Future<void> setBrightness(double value) async {
     try {
-      await ScreenBrightness().setScreenBrightness(value);
+      await ScreenBrightness().setApplicationScreenBrightness(value);
     } catch (_) {}
     _ctr.brightnessIndicator.value = true;
     _brightnessTimer?.cancel();
@@ -615,9 +615,12 @@ class _PLVideoPlayerState extends State<PLVideoPlayer>
                 buffered: Duration(seconds: buffer),
                 total: Duration(seconds: max),
                 progressBarColor: colorTheme,
-                baseBarColor: Colors.white.withOpacity(0.2),
-                bufferedBarColor:
-                    Theme.of(context).colorScheme.primary.withOpacity(0.4),
+                baseBarColor:
+                    Colors.white.withAlpha((0.2 * 255).round()),
+                bufferedBarColor: Theme.of(context)
+                    .colorScheme
+                    .primary
+                    .withAlpha((0.4 * 255).round()),
                 timeLabelLocation: TimeLabelLocation.none,
                 thumbColor: colorTheme,
                 barHeight: 3,

--- a/lib/app/components/plugin/pl_player/widgets/app_bar_ani.dart
+++ b/lib/app/components/plugin/pl_player/widgets/app_bar_ani.dart
@@ -2,12 +2,12 @@ import 'package:flutter/material.dart';
 
 class AppBarAni extends StatelessWidget implements PreferredSizeWidget {
   const AppBarAni({
+    super.key,
     required this.child,
     required this.controller,
     required this.visible,
     this.position,
-    Key? key,
-  }) : super(key: key);
+  });
 
   final PreferredSizeWidget child;
   final AnimationController controller;

--- a/lib/app/components/plugin/pl_player/widgets/backward_seek.dart
+++ b/lib/app/components/plugin/pl_player/widgets/backward_seek.dart
@@ -7,10 +7,10 @@ class BackwardSeekIndicator extends StatefulWidget {
   final void Function(Duration) onChanged;
   final void Function(Duration) onSubmitted;
   const BackwardSeekIndicator({
-    Key? key,
+    super.key,
     required this.onChanged,
     required this.onSubmitted,
-  }) : super(key: key);
+  });
 
   @override
   State<BackwardSeekIndicator> createState() => BackwardSeekIndicatorState();

--- a/lib/app/components/plugin/pl_player/widgets/bottom_control.dart
+++ b/lib/app/components/plugin/pl_player/widgets/bottom_control.dart
@@ -9,8 +9,7 @@ import 'play_pause_btn.dart';
 class BottomControl extends StatelessWidget implements PreferredSizeWidget {
   final PlPlayerController? controller;
   final Function? triggerFullScreen;
-  const BottomControl({this.controller, this.triggerFullScreen, Key? key})
-      : super(key: key);
+  const BottomControl({this.controller, this.triggerFullScreen, super.key});
 
   @override
   Size get preferredSize => const Size(double.infinity, kToolbarHeight);
@@ -46,8 +45,10 @@ class BottomControl extends StatelessWidget implements PreferredSizeWidget {
                   buffered: Duration(seconds: buffer),
                   total: Duration(seconds: max),
                   progressBarColor: colorTheme,
-                  baseBarColor: Colors.white.withOpacity(0.2),
-                  bufferedBarColor: colorTheme.withOpacity(0.4),
+                  baseBarColor:
+                      Colors.white.withAlpha((0.2 * 255).round()),
+                  bufferedBarColor:
+                      colorTheme.withAlpha((0.4 * 255).round()),
                   timeLabelLocation: TimeLabelLocation.none,
                   thumbColor: colorTheme,
                   barHeight: 3.5,

--- a/lib/app/components/plugin/pl_player/widgets/common_btn.dart
+++ b/lib/app/components/plugin/pl_player/widgets/common_btn.dart
@@ -17,7 +17,7 @@ class ComBtn extends StatelessWidget {
       height: 34,
       child: IconButton(
         style: ButtonStyle(
-          padding: MaterialStateProperty.all(EdgeInsets.zero),
+          padding: WidgetStateProperty.all<EdgeInsets>(EdgeInsets.zero),
         ),
         onPressed: () {
           fuc!();

--- a/lib/app/components/plugin/pl_player/widgets/forward_seek.dart
+++ b/lib/app/components/plugin/pl_player/widgets/forward_seek.dart
@@ -7,10 +7,10 @@ class ForwardSeekIndicator extends StatefulWidget {
   final void Function(Duration) onChanged;
   final void Function(Duration) onSubmitted;
   const ForwardSeekIndicator({
-    Key? key,
+    super.key,
     required this.onChanged,
     required this.onSubmitted,
-  }) : super(key: key);
+  });
 
   @override
   State<ForwardSeekIndicator> createState() => ForwardSeekIndicatorState();

--- a/lib/app/components/plugin/pl_player/widgets/play_pause_btn.dart
+++ b/lib/app/components/plugin/pl_player/widgets/play_pause_btn.dart
@@ -69,7 +69,7 @@ class PlayOrPauseButtonState extends State<PlayOrPauseButton>
       height: 34,
       child: IconButton(
         style: ButtonStyle(
-          padding: MaterialStateProperty.all(EdgeInsets.zero),
+          padding: WidgetStateProperty.all<EdgeInsets>(EdgeInsets.zero),
         ),
         onPressed: player.playOrPause,
         color: Colors.white,

--- a/lib/app/components/user_comment.dart
+++ b/lib/app/components/user_comment.dart
@@ -28,7 +28,7 @@ class UserComment extends StatefulWidget {
   final void Function(Map)? onUpdated;
 
   const UserComment({
-    Key? key,
+    super.key,
     required this.comment,
     required this.uploaderUserName,
     this.showReplies = true,
@@ -38,7 +38,7 @@ class UserComment extends StatefulWidget {
     this.sourceType,
     this.isMyComment = false,
     this.onUpdated,
-  }) : super(key: key);
+  });
 
   @override
   State<StatefulWidget> createState() => _UserCommentState();

--- a/lib/app/components/user_preview/users_preview_list/repository.dart
+++ b/lib/app/components/user_preview/users_preview_list/repository.dart
@@ -26,8 +26,6 @@ class UsersPreviewListRepository {
         path = "/search";
         queryParameters.addAll({"type": "user", "query": sortSetting.keyword});
         break;
-      default:
-        break;
     }
 
     return ApiProvider.getUsers(

--- a/lib/app/modules/account/downloads/widgets/download_task_dialog.dart
+++ b/lib/app/modules/account/downloads/widgets/download_task_dialog.dart
@@ -220,7 +220,7 @@ class DownloadTaskDialog extends StatelessWidget {
                 child: _buildStateWidget(context),
               ),
             Obx(
-              () => ButtonBar(
+              () => OverflowBar(
                 alignment: MainAxisAlignment.end,
                 children: [
                   if (taskStatus?.value.status == null ||

--- a/lib/app/modules/account/downloads/widgets/downloads_media_preview_list/widget.dart
+++ b/lib/app/modules/account/downloads/widgets/downloads_media_preview_list/widget.dart
@@ -164,18 +164,23 @@ class _DownloadsMediaPreviewListState extends State<DownloadsMediaPreviewList>
                           },
                           onOpen: (taskId) async {
                             OpenFile.open(
-                                (await _controller.downloadService
-                                    .getTaskFilePath(taskId))!,
-                                type: 'video/mp4',
-                                uti: 'public.mpeg-4');
+                              (await _controller.downloadService
+                                  .getTaskFilePath(taskId))!,
+                              type: 'video/mp4',
+                            );
                           },
                           onShare: (taskId) async {
-                            Share.shareXFiles([
-                              XFile(
-                                  (await _controller.downloadService
-                                      .getTaskFilePath(taskId))!,
-                                  mimeType: 'video/mp4')
-                            ]);
+                            SharePlus.instance.share(
+                              ShareParams(
+                                files: [
+                                  XFile(
+                                    (await _controller.downloadService
+                                        .getTaskFilePath(taskId))!,
+                                    mimeType: 'video/mp4',
+                                  )
+                                ],
+                              ),
+                            );
                           },
                           gotoPlayer: gotoPlayer,
                           gotoDetail: gotoDetail,

--- a/lib/app/modules/account/favorites/widgets/favorite_media_preview_list/widget.dart
+++ b/lib/app/modules/account/favorites/widgets/favorite_media_preview_list/widget.dart
@@ -60,10 +60,12 @@ class _FavoriteMediaPreviewListState extends State<FavoriteMediaPreviewList>
             child: Container(
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(8),
-                color: Colors.black.withOpacity(
-                    _parentController.enableMultipleSelection && checked
-                        ? 0.6
-                        : 0),
+                color: Colors.black.withAlpha(
+                    ((_parentController.enableMultipleSelection && checked
+                                ? 0.6
+                                : 0) *
+                            255)
+                        .round()),
               ),
               child: Center(
                 child: SizedBox(
@@ -80,7 +82,7 @@ class _FavoriteMediaPreviewListState extends State<FavoriteMediaPreviewList>
                         color: (Theme.of(context).brightness == Brightness.light
                                 ? Colors.white
                                 : Colors.black)
-                            .withOpacity(0.8),
+                            .withAlpha((0.8 * 255).round()),
                       ),
                       child: Icon(
                         Icons.check,

--- a/lib/app/modules/account/friends/page.dart
+++ b/lib/app/modules/account/friends/page.dart
@@ -7,7 +7,7 @@ import 'widgets/friend_requests_list/widget.dart';
 import 'widgets/friends_preview_list/widget.dart';
 
 class FriendsPage extends GetView<FriendsController> {
-  const FriendsPage({Key? key}) : super(key: key);
+  const FriendsPage({super.key});
 
   Widget _buildTabBar(BuildContext context) {
     return Container(

--- a/lib/app/modules/account/history/widgets/history_media_preview.dart
+++ b/lib/app/modules/account/history/widgets/history_media_preview.dart
@@ -18,14 +18,14 @@ class HistoryMediaPreview extends StatelessWidget {
   final void Function()? onLongPress;
 
   const HistoryMediaPreview({
-    Key? key,
+    super.key,
     required this.historyController,
     required this.media,
     this.checked = false,
     this.showType = true,
     this.onTap,
     this.onLongPress,
-  }) : super(key: key);
+  });
 
   Widget _buildBadges(BuildContext context) {
     Duration? duration;
@@ -152,10 +152,12 @@ class HistoryMediaPreview extends StatelessWidget {
                 child: Container(
                   decoration: BoxDecoration(
                     borderRadius: BorderRadius.circular(8),
-                    color: Colors.black.withOpacity(
-                        historyController.enableMultipleSelection && checked
-                            ? 0.6
-                            : 0),
+                    color: Colors.black.withAlpha(
+                        ((historyController.enableMultipleSelection && checked
+                                    ? 0.6
+                                    : 0) *
+                                255)
+                            .round()),
                   ),
                   child: Center(
                     child: SizedBox(
@@ -173,7 +175,7 @@ class HistoryMediaPreview extends StatelessWidget {
                                         Brightness.light
                                     ? Colors.white
                                     : Colors.black)
-                                .withOpacity(0.8),
+                                .withAlpha((0.8 * 255).round()),
                           ),
                           child: Icon(
                             Icons.check,

--- a/lib/app/modules/forum/create_thread/page.dart
+++ b/lib/app/modules/forum/create_thread/page.dart
@@ -34,7 +34,7 @@ class CreateThreadPage extends GetView<CreateThreadController> {
                   color: Theme.of(context)
                       .colorScheme
                       .secondaryContainer
-                      .withOpacity(0.3),
+                      .withAlpha((0.3 * 255).round()),
                   borderRadius: BorderRadius.circular(12),
                 ),
                 padding:
@@ -66,7 +66,7 @@ class CreateThreadPage extends GetView<CreateThreadController> {
                     color: Theme.of(context)
                         .colorScheme
                         .secondaryContainer
-                        .withOpacity(0.3),
+                        .withAlpha((0.3 * 255).round()),
                     borderRadius: BorderRadius.circular(16),
                   ),
                   padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),

--- a/lib/app/modules/forum/thread/widgets/edit_post_bottom_sheet/widget.dart
+++ b/lib/app/modules/forum/thread/widgets/edit_post_bottom_sheet/widget.dart
@@ -30,7 +30,7 @@ class EditPostBottomSheet extends GetWidget<EditPostBottomSheetController> {
           topLeft: Radius.circular(12),
           topRight: Radius.circular(12),
         ),
-        color: Theme.of(context).colorScheme.background,
+        color: Theme.of(context).colorScheme.surface,
       ),
       padding: EdgeInsets.only(
         bottom: Get.mediaQuery.padding.bottom,

--- a/lib/app/modules/forum/thread/widgets/post.dart
+++ b/lib/app/modules/forum/thread/widgets/post.dart
@@ -21,14 +21,14 @@ class Post extends StatefulWidget {
   final void Function(Map)? onUpdated;
 
   const Post({
-    Key? key,
+    super.key,
     required this.post,
     required this.index,
     this.showDivider = true,
     required this.starterUserName,
     this.isMyComment = false,
     this.onUpdated,
-  }) : super(key: key);
+  });
 
   @override
   State<StatefulWidget> createState() => _PostState();

--- a/lib/app/modules/forum/thread/widgets/posts_list/widget.dart
+++ b/lib/app/modules/forum/thread/widgets/posts_list/widget.dart
@@ -15,14 +15,14 @@ class PostList extends StatefulWidget {
   final ScrollController? scrollController;
 
   const PostList({
-    Key? key,
+    super.key,
     required this.tag,
     required this.title,
     required this.starterUserName,
     required this.channelName,
     required this.threadId,
     this.scrollController,
-  }) : super(key: key);
+  });
 
   @override
   State<PostList> createState() => _PostListState();

--- a/lib/app/modules/home/page.dart
+++ b/lib/app/modules/home/page.dart
@@ -12,7 +12,7 @@ class HomePage extends GetView<HomeController> {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: false,
-      onPopInvoked: (bool didPop) async {
+      onPopInvokedWithResult: (bool didPop, Object? result) async {
         controller.onBackPressed(context);
       },
       child: Scaffold(

--- a/lib/app/modules/media_detail/controller.dart
+++ b/lib/app/modules/media_detail/controller.dart
@@ -238,7 +238,7 @@ class MediaDetailController extends GetxController
   /// 更新画质、音质
   /// TODO 继续进度播放
   updatePlayer({
-    video,
+    String? video,
   }) {
     defaultST = plPlayerController.position.value;
     plPlayerController.removeListeners();
@@ -249,18 +249,18 @@ class MediaDetailController extends GetxController
   }
 
   Future playerInit({
-    video,
-    audio,
-    seekToTime,
+    String? video,
+    String? audio,
+    Duration? seekToTime,
     bool autoplay = true,
   }) async {
     _isLoadingPlayer.value = true;
 
     /// 设置/恢复 屏幕亮度
     if (brightness != null) {
-      ScreenBrightness().setScreenBrightness(brightness!);
+      ScreenBrightness().setApplicationScreenBrightness(brightness!);
     } else {
-      ScreenBrightness().resetScreenBrightness();
+      ScreenBrightness().resetApplicationScreenBrightness();
     }
 
     await plPlayerController.setDataSource(

--- a/lib/app/modules/media_detail/page.dart
+++ b/lib/app/modules/media_detail/page.dart
@@ -376,11 +376,19 @@ class _MediaDetailPageState extends State<MediaDetailPage>
               t.media.share,
               () {
                 if (_controller.mediaType == MediaType.video) {
-                  Share.share(IwaraConst.videoPageUrl
-                      .replaceAll("{id}", _controller.media.id));
+                  SharePlus.instance.share(
+                    ShareParams(
+                      text: IwaraConst.videoPageUrl
+                          .replaceAll("{id}", _controller.media.id),
+                    ),
+                  );
                 } else {
-                  Share.share(IwaraConst.imagePageUrl
-                      .replaceAll("{id}", _controller.media.id));
+                  SharePlus.instance.share(
+                    ShareParams(
+                      text: IwaraConst.imagePageUrl
+                          .replaceAll("{id}", _controller.media.id),
+                    ),
+                  );
                 }
               },
             ),
@@ -796,7 +804,7 @@ class _MediaDetailPageState extends State<MediaDetailPage>
   Widget _buildPLPlayer([bool inPip = false]) {
     return PopScope(
       canPop: plPlayerController?.isFullScreen.value != true,
-      onPopInvoked: (bool didPop) {
+      onPopInvokedWithResult: (bool didPop, Object? result) {
         if (plPlayerController?.isFullScreen.value == true) {
           plPlayerController!.triggerFullScreen(status: false);
         }

--- a/lib/app/modules/media_detail/widgets/header_control.dart
+++ b/lib/app/modules/media_detail/widgets/header_control.dart
@@ -94,10 +94,11 @@ class _HeaderControlState extends State<HeaderControl> {
             fuc: () async {
               // 销毁播放器实例
               await widget.controller!.dispose(type: 'all');
-              if (mounted) {
-                Navigator.popUntil(
-                    context, ModalRoute.withName(AppRoutes.home));
-              }
+              if (!mounted) return;
+              Navigator.popUntil(
+                context,
+                ModalRoute.withName(AppRoutes.home),
+              );
             },
           ),
           const Spacer(),

--- a/lib/app/modules/playlists/playlist_detail/widgets/playlist_detail_media_preview_list/widget.dart
+++ b/lib/app/modules/playlists/playlist_detail/widgets/playlist_detail_media_preview_list/widget.dart
@@ -68,10 +68,12 @@ class _PlaylistDetailMediaPreviewListState
             child: Container(
               decoration: BoxDecoration(
                 borderRadius: BorderRadius.circular(8),
-                color: Colors.black.withOpacity(
-                    _parentController.enableMultipleSelection && checked
-                        ? 0.6
-                        : 0),
+                color: Colors.black.withAlpha(
+                    ((_parentController.enableMultipleSelection && checked
+                                ? 0.6
+                                : 0) *
+                            255)
+                        .round()),
               ),
               child: Center(
                 child: SizedBox(
@@ -88,7 +90,7 @@ class _PlaylistDetailMediaPreviewListState
                         color: (Theme.of(context).brightness == Brightness.light
                                 ? Colors.white
                                 : Colors.black)
-                            .withOpacity(0.8),
+                            .withAlpha((0.8 * 255).round()),
                       ),
                       child: Icon(
                         Icons.check,

--- a/lib/app/modules/rules/page.dart
+++ b/lib/app/modules/rules/page.dart
@@ -67,7 +67,7 @@ class RulesPage extends GetView<RulesController> {
               _buildMarkdown(context, rule.body[language] ?? ''),
             ],
           );
-        }).toList(),
+        }),
         FilledButton(
           child: Text(t.rules.accept),
           onPressed: () {

--- a/lib/app/modules/settings/widgets/custom_color_page.dart
+++ b/lib/app/modules/settings/widgets/custom_color_page.dart
@@ -53,13 +53,15 @@ class _CustomColorPageState extends State<CustomColorPage> {
                                 width: 46,
                                 height: 46,
                                 decoration: BoxDecoration(
-                                  color: e['color'].withOpacity(0.8),
+                                  color:
+                                      e['color'].withAlpha((0.8 * 255).round()),
                                   shape: BoxShape.circle,
                                   border: Border.all(
                                     width: 2,
                                     color: _configService.customColor == index
                                         ? Colors.black
-                                        : e['color'].withOpacity(0.8),
+                                        : e['color']
+                                            .withAlpha((0.8 * 255).round()),
                                   ),
                                 ),
                                 child: AnimatedOpacity(


### PR DESCRIPTION
## Summary
- update `share_plus` usage and remove obsolete `uti` parameter
- switch Material `withOpacity` calls to `withAlpha`
- use `WidgetStateProperty` and super parameters
- replace `ButtonBar` with `OverflowBar`
- handle `PopScope` using `onPopInvokedWithResult`
- clarify BuildContext usage after awaits

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_687dc096c6c8832c8671eefe92e729f2