### PR TITLE
Fix invalid path when changing download folder on Android 15

### DIFF
--- a/lib/app/data/services/download_service.dart
+++ b/lib/app/data/services/download_service.dart
@@ -190,9 +190,15 @@ class DownloadService extends GetxService {
 
   bool checkPermissionForPath(String path) {
     try {
-      File file = File(join(path, '.iwrqktest'));
-      file.createSync(recursive: true);
-      file.deleteSync();
+      final dir = Directory(path);
+      if (!dir.existsSync()) {
+        dir.createSync(recursive: true);
+      }
+
+      // Try to write a temporary file to ensure the directory is writable.
+      final testFile = File(join(dir.path, '.iwrqktest'));
+      testFile.writeAsStringSync('');
+      testFile.deleteSync();
     } on FileSystemException catch (e) {
       LogUtil.error('${'invalidPath'.tr}:$path', e);
       return false;


### PR DESCRIPTION
## Summary
- update download path check to create directory before verifying it

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_68873b2d6acc832c9c1aa08d9735f5ce