### PR TITLE
Use Directory object for download paths

### DIFF
--- a/lib/app/modules/settings/controller.dart
+++ b/lib/app/modules/settings/controller.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
@@ -71,11 +73,12 @@ class SettingsController extends GetxController {
     StorageProvider.config[PLPlayerConfigKey.enableBackgroundPlay] = value;
   }
 
-  final RxString _downloadPath = ''.obs;
-  String get downloadPath => _downloadPath.value;
-  set downloadPath(String value) {
+  final Rx<Directory?> _downloadPath = Rx<Directory?>(null);
+  Directory? get downloadPath => _downloadPath.value;
+  String get downloadPathText => _downloadPath.value?.path ?? 'N/A';
+  set downloadPath(Directory? value) {
     _downloadPath.value = value;
-    StorageProvider.config[StorageKey.downloadDirectory] = value;
+    StorageProvider.config[StorageKey.downloadDirectory] = value?.path;
     downloadService.resetAllowMediaScan();
   }
 
@@ -105,7 +108,7 @@ class SettingsController extends GetxController {
     _autoPlay.value =
         configService.setting[PLPlayerConfigKey.enableQuickDouble] ?? true;
 
-    _downloadPath.value = downloadService.downloadDirectory ?? "N/A";
+    _downloadPath.value = downloadService.downloadDirectory;
 
     _backgroundPlay.value =
         configService.setting[PLPlayerConfigKey.enableBackgroundPlay] ?? false;
@@ -145,7 +148,7 @@ class SettingsController extends GetxController {
       return;
     }
 
-    downloadPath = result;
+    downloadPath = Directory(result);
   }
 
   void clearLogs() async {

--- a/lib/app/modules/settings/page.dart
+++ b/lib/app/modules/settings/page.dart
@@ -259,7 +259,7 @@ class SettingsPage extends GetView<SettingsController> {
       () => _buildButton(
         context,
         title: t.settings.download_path,
-        description: controller.downloadPath,
+        description: controller.downloadPathText,
         iconData: Icons.download,
         onPressed: controller.changeDownloadPath,
       ),

--- a/lib/app/utils/directory_extension.dart
+++ b/lib/app/utils/directory_extension.dart
@@ -1,0 +1,10 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+extension DirectoryExtension on Directory {
+  /// Returns a [File] object pointing to [name] under this directory.
+  File file(String name) => File(p.join(path, name));
+
+  /// Returns a [Directory] object for a child directory named [name].
+  Directory dir(String name) => Directory(p.join(path, name));
+}


### PR DESCRIPTION
## Summary
- add `DirectoryExtension` for easier path operations
- update `DownloadService` to return `Directory` for download path
- adjust download tasks to use directory methods
- track selected download directory as `Directory` in settings
- update settings page to display string path via `downloadPathText`

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6887517890e8832c93fea9e964f2dc35