### PR TITLE
Desktop window improvements

### DIFF
--- a/lib/app/modules/media_detail/page.dart
+++ b/lib/app/modules/media_detail/page.dart
@@ -808,7 +808,8 @@ class _MediaDetailPageState extends State<MediaDetailPage>
         if (plPlayerController?.isFullScreen.value == true) {
           plPlayerController!.triggerFullScreen(status: false);
         }
-        if (MediaQuery.of(context).orientation == Orientation.landscape) {
+        if (!GetPlatform.isDesktop &&
+            MediaQuery.of(context).orientation == Orientation.landscape) {
           verticalScreen();
         }
       },
@@ -833,8 +834,9 @@ class _MediaDetailPageState extends State<MediaDetailPage>
   Widget _buildPageFuture([bool inPip = false]) {
     Widget child;
     return Obx(() {
-      if (Get.mediaQuery.orientation == Orientation.landscape ||
-          plPlayerController?.isFullScreen.value == true) {
+      if (plPlayerController?.isFullScreen.value == true ||
+          (!GetPlatform.isDesktop &&
+              Get.mediaQuery.orientation == Orientation.landscape)) {
         enterFullScreen();
       } else {
         exitFullScreen();
@@ -854,7 +856,8 @@ class _MediaDetailPageState extends State<MediaDetailPage>
           } else {
             Widget child;
             if (plPlayerController?.isFullScreen.value == true ||
-                Get.mediaQuery.orientation == Orientation.landscape) {
+                (!GetPlatform.isDesktop &&
+                    Get.mediaQuery.orientation == Orientation.landscape)) {
               child = _controller.mediaType == MediaType.video
                   ? _buildPlayer()
                   : _buildGallery();
@@ -889,7 +892,8 @@ class _MediaDetailPageState extends State<MediaDetailPage>
                   ),
                 ),
                 body: plPlayerController?.isFullScreen.value == true ||
-                        Get.mediaQuery.orientation == Orientation.landscape
+                        (!GetPlatform.isDesktop &&
+                            Get.mediaQuery.orientation == Orientation.landscape)
                     ? buildMedia()
                     : Column(
                         children: [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,8 +68,8 @@ Future<void> main() async {
       backgroundColor: Colors.transparent,
       skipTaskbar: false,
       title: 'IwrQk',
-      titleBarStyle:
-          GetPlatform.isWindows ? TitleBarStyle.hidden : TitleBarStyle.normal,
+      // Show the native title bar on desktop for easier window control
+      titleBarStyle: TitleBarStyle.normal,
     );
 
     windowManager.waitUntilReadyToShow(windowOptions, () async {


### PR DESCRIPTION
## Summary
- show native title bar on desktop to allow moving the window
- avoid entering fullscreen when the window is landscape on desktop

## Testing
- `dart format -o none --set-exit-if-changed lib/main.dart lib/app/modules/media_detail/page.dart`
- `dart analyze`

------
https://chatgpt.com/codex/tasks/task_e_6887693fc148832c976393f954b77a4f