### PR TITLE
Improve desktop experience

### DIFF
--- a/lib/app/modules/media_detail/page.dart
+++ b/lib/app/modules/media_detail/page.dart
@@ -808,7 +808,8 @@ class _MediaDetailPageState extends State<MediaDetailPage>
         if (plPlayerController?.isFullScreen.value == true) {
           plPlayerController!.triggerFullScreen(status: false);
         }
-        if (MediaQuery.of(context).orientation == Orientation.landscape) {
+        if (!GetPlatform.isDesktop &&
+            MediaQuery.of(context).orientation == Orientation.landscape) {
           verticalScreen();
         }
       },
@@ -833,8 +834,10 @@ class _MediaDetailPageState extends State<MediaDetailPage>
   Widget _buildPageFuture([bool inPip = false]) {
     Widget child;
     return Obx(() {
-      if (Get.mediaQuery.orientation == Orientation.landscape ||
-          plPlayerController?.isFullScreen.value == true) {
+      if (plPlayerController?.isFullScreen.value == true) {
+        enterFullScreen();
+      } else if (!GetPlatform.isDesktop &&
+          Get.mediaQuery.orientation == Orientation.landscape) {
         enterFullScreen();
       } else {
         exitFullScreen();
@@ -854,7 +857,8 @@ class _MediaDetailPageState extends State<MediaDetailPage>
           } else {
             Widget child;
             if (plPlayerController?.isFullScreen.value == true ||
-                Get.mediaQuery.orientation == Orientation.landscape) {
+                (!GetPlatform.isDesktop &&
+                    Get.mediaQuery.orientation == Orientation.landscape)) {
               child = _controller.mediaType == MediaType.video
                   ? _buildPlayer()
                   : _buildGallery();
@@ -889,7 +893,8 @@ class _MediaDetailPageState extends State<MediaDetailPage>
                   ),
                 ),
                 body: plPlayerController?.isFullScreen.value == true ||
-                        Get.mediaQuery.orientation == Orientation.landscape
+                        (!GetPlatform.isDesktop &&
+                            Get.mediaQuery.orientation == Orientation.landscape)
                     ? buildMedia()
                     : Column(
                         children: [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -63,13 +63,12 @@ Future<void> main() async {
   }
 
   if (GetPlatform.isDesktop) {
-    WindowOptions windowOptions = WindowOptions(
+    WindowOptions windowOptions = const WindowOptions(
       center: true,
       backgroundColor: Colors.transparent,
       skipTaskbar: false,
       title: 'IwrQk',
-      titleBarStyle:
-          GetPlatform.isWindows ? TitleBarStyle.hidden : TitleBarStyle.normal,
+      titleBarStyle: TitleBarStyle.normal,
     );
 
     windowManager.waitUntilReadyToShow(windowOptions, () async {


### PR DESCRIPTION
## Summary
- show normal title bar on desktop
- don't auto switch to fullscreen layout on desktop

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory "test" not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887693fc148832c976393f954b77a4f